### PR TITLE
Draft: Implement make_compound function

### DIFF
--- a/src/geoml/utilities/utilities.cpp
+++ b/src/geoml/utilities/utilities.cpp
@@ -64,4 +64,19 @@ Shape make_fillet (Shape const& solid , Shape const& edges, Standard_Real radius
     return operation.value();
 }
 
+TopoDS_Shape make_compound (const std::vector<TopoDS_Shape> & shapes)
+{
+    TopoDS_Compound compound;  
+    BRep_Builder builder;
+    builder.MakeCompound(compound);
+
+    for (auto shape: shapes)
+    {
+        builder.Add(compound, shape);
+    }
+
+    return compound;
+}
+
+
 } // namespace geoml

--- a/src/geoml/utilities/utilities.h
+++ b/src/geoml/utilities/utilities.h
@@ -54,4 +54,11 @@ extract_control_point_vector_in_V_direction (const Handle(Geom_BSplineSurface) &
  */
 GEOML_API_EXPORT Shape make_fillet (Shape const& solid , Shape const& edges, Standard_Real radius);
 
+/**
+ * @brief Make a compound of a vector of TopoDS_Shapes
+ *
+ * @param shapes The vector of shapes    
+ */
+GEOML_API_EXPORT TopoDS_Shape make_compound (const std::vector<TopoDS_Shape> &shapes);
+
 } // namespace geoml


### PR DESCRIPTION
In GitLab by @AntonReiswich on Feb 21, 2025, 14:57

Currently, the function `make_compound` is implemented as in the branch `add-geometry-functionality-in-particular-for-use-cases`.
It takes an `std::vector` of `TopoDS_Shape`s as an argument and returns a `TopoDS_Shape`.

Let us discuss the API:
* Do we want to keep it that way?
* Do we want the argument to be of type `std::vector<Shape>` and the return type to be `Shape`?
* Do we want the argument to be of type `Shape`, as it is a container type, holding `Shape`s itself?
* Do we want to overload the function?